### PR TITLE
fix: accepts headers for Request.header

### DIFF
--- a/lib/brains.ex
+++ b/lib/brains.ex
@@ -126,7 +126,7 @@ defmodule Brains do
 
         headers ->
           Enum.reduce(headers, request, fn {key, value}, req ->
-            Request.add_param(req, :headers, key, value)
+            Request.add_param(req, :header, key, value)
           end)
       end
 


### PR DESCRIPTION
A simple fix.
It redirects `headers:` to Request as header

This fixes #3.